### PR TITLE
rolling_update fix backport from official TF mod v0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Additional resources for load balanced environments:
 | notification\_topic\_arn | Notification topic arn | string | `""` | no |
 | notification\_topic\_name | Notification topic name | string | `""` | no |
 | preferred\_start\_time | Configure a maintenance window for managed actions in UTC | string | `"Sun:10:00"` | no |
+| rolling\_\update\_enabled | Enable rolling updates | string | "true" | no | 
 | rolling\_update\_type | Set it to Immutable to apply the configuration change to a fresh group of instances | string | `"Health"` | no |
 | root\_volume\_size | The size of the EBS root volume | string | `"8"` | no |
 | root\_volume\_type | The type of the EBS root volume | string | `"gp2"` | no |

--- a/main.tf
+++ b/main.tf
@@ -369,7 +369,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:updatepolicy:rollingupdate"
     name      = "RollingUpdateEnabled"
-    value     = "true"
+    value     = var.rolling_update_enabled
   }
 
   setting {
@@ -944,4 +944,3 @@ resource "aws_route53_record" "default" {
     evaluate_target_health = "false"
   }
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -171,6 +171,11 @@ variable "availability_zones" {
   description = "Choose the number of AZs for your instances"
 }
 
+variable "rolling_update_enabled" {
+  default     = true
+  description = "Enable rolling updates"
+}
+
 variable "rolling_update_type" {
   default     = "Health"
   description = "Set it to Immutable to apply the configuration change to a fresh group of instances"
@@ -356,4 +361,3 @@ variable "composer_options" {
   description = "Sets custom options to use when installing dependencies using Composer through composer.phar install."
   # For more information including available options, go to http://getcomposer.org/doc/03-cli.md#install.
 }
-


### PR DESCRIPTION
This change allows rolling updates to be disabled. It was back ported from v0.14 of the official terraform Elastic Beanstalk module. In v0.13 and prior enabled rolling updates were hard coded.